### PR TITLE
v1.6 doesn't work anymore. Changes for v2.1.2

### DIFF
--- a/sitearchive.py
+++ b/sitearchive.py
@@ -1,4 +1,4 @@
-﻿"""Simple Python 3 web crawler, to be extended for various uses.
+"""Simple Python 3 web crawler, to be extended for various uses.
 """
 import collections
 import string
@@ -168,7 +168,7 @@ def getwords(rawtext):
 
 
 def pagehandler(pageurl, pageresponse, soup):
-    archived_url = waybackpy.save(pageurl, UA = "Any-User-Agent")
+    archived_url = waybackpy.Url(pageurl, "Any-User-Agent").save()
     print(pageurl + ' Crawled')
     print("Crawling:" + pageurl + " ({0} bytes)".format(len(pageresponse.text)))
     # wordcount(soup) # display unique word counts


### PR DESCRIPTION
- See the latest usage at https://github.com/akamhy/waybackpy
- And update the library if you are using it anywhere. Wayback machine API changed last week. `pip install waybackpy -U`